### PR TITLE
add note + update to v0.12.0

### DIFF
--- a/gh.json
+++ b/gh.json
@@ -1,22 +1,24 @@
 {
-    "version": "0.11.1",
+    "version": "0.12.0",
     "architecture": {
-        "32bit": {
-            "url": "https://github.com/cli/cli/releases/download/v0.11.1/gh_0.11.1_windows_386.zip",
-            "bin": [
-                "bin/gh.exe"
-            ],
-            "hash": "aae2cfeead222eb504d527033c95e853a0b1eb685009a5bcc8bca20af98eb8bb"
-        },
         "64bit": {
-            "url": "https://github.com/cli/cli/releases/download/v0.11.1/gh_0.11.1_windows_amd64.zip",
-            "bin": [
-                "bin/gh.exe"
-            ],
-            "hash": "0ff00a7d89d1b638a6f3cbce6a09902c5a3d1759ed28463971c9bc2e008caf63"
+            "url": "https://github.com/cli/cli/releases/download/v0.12.0/gh_0.12.0_windows_amd64.zip",
+            "hash": "6f79296f7c37121ee5853d79a1241eb7d3ba892d491953db1d375a498c4b84ad"
+        },
+        "32bit": {
+            "url": "https://github.com/cli/cli/releases/download/v0.12.0/gh_0.12.0_windows_386.zip",
+            "hash": "ab9ff7487e3b684819a0f67a7522d29271dfc4c3f227de7cf00bfe31ac02c698"
         }
     },
+    "bin": "bin\\gh.exe",
     "homepage": "https://github.com/cli/cli",
     "license": "MIT",
-    "description": "GitHub CLI"
+    "description": "GitHub CLI",
+    "notes": [
+        "The bucket you are using to install this (gh) is not going to be maintained anymore.",
+        "Please run the following to re-install 'gh' from the Main bucket instead:",
+        "   1. 'scoop bucket rm github-gh'",
+        "   2. 'scoop uninstall gh",
+        "   3. 'scoop install gh"
+    ]
 }


### PR DESCRIPTION
Same as #7 but with a note that this bucket isn't going to be maintained and how to use the [Main bucket](https://github.com/ScoopInstaller/Main) instead. Please ignore this if this is going to be maintained (even though it is already on the [Main bucket](https://github.com/ScoopInstaller/Main) which is up to date. See [my other PR](https://github.com/cli/cli/pull/1689) for more information.